### PR TITLE
Update script.coffee

### DIFF
--- a/website/script.coffee
+++ b/website/script.coffee
@@ -4,7 +4,8 @@ marked.setOptions
 setUp=()->
 	$('#cont').html "<p class='text-center'><i class='icon-spinner icon-spin icon-4x'></i>loading...</p>"
 setUp()
-if typeof window.Worker is 'function'
+type = typeof window.Worker
+if type in ['function','object']
 	setUp()
 	communist.ajax('README.md',(d)->
 		d.slice(66)


### PR DESCRIPTION
on ios, the typeof window.Worker is an object not a function. This causes the website to not function on ios safari.
