### PR TITLE
Depreciate ajax

### DIFF
--- a/API.md
+++ b/API.md
@@ -264,8 +264,6 @@ we have a few utility functions you can use
 
 `cw.worker([array of strings]);` returns worker made from those strings.
 
-```cw.ajax(url[,after,notjson]);``` returns promise, after is a function to call on the data after download in the worker, notjson should be true if you don't want to run JSON.parse on it.
-
 `cw.deferred();` makes a new promise and returns it, used internally. Technically `cw` is a shortcut to [Promiscuous](https://github.com/RubenVerborgh/promiscuous/) which is used for promises, so any of Promiscuous's methods can be used, aka call `cw.resolve(value)` for an already resolved promise and `cw.reject(reason)` for a rejected one. Lastly you can call `cw.all([promises])` on an array of promises, should work just like `Q.all()`.
 
 `cw.setImmediate();` implements [setImmediate](https://github.com/NobleJS/setImmediate), at least the parts that apply to non web workers that can create web workers.

--- a/test/test.js
+++ b/test/test.js
@@ -184,23 +184,6 @@ describe('cw()', function () {
 		        .close().then(function (a) { a.should.equal(91); }).then(done, done);
 		});
 	});
-	describe('Ajax', function () {
-		it('should work loading ' + cw.makeUrl('test.json'), function (done) {
-			cw.ajax("test.json").then(function(a){ a.should.deep.equal({"a":1,"b":2}); }).then(done, done);
-		});
-		it('should work with after set', function (done) {
-			cw.ajax("test.json",function(a){a.c=3;return a;}).then(function(a){ a.should.deep.equal({"a":1,"b":2,"c":3}); }).then(done, done);
-		});
-		it('should work with after set to async', function (done) {
-			cw.ajax("test.json",function(a,cb){a.c=3;cb(a);}).then(function(a){ a.should.deep.equal({"a":1,"b":2,"c":3}); }).then(done, done);
-		});
-		it('should work with text', function (done) {
-			cw.ajax("test.json",function(a){return a.split("");},true).then(function(a){ a.should.deep.equal(["{", '"', "a", '"', ":", "1", ",", '"', "b", '"', ":", "2", "}"]); }).then(done, done);
-		});
-		it('should work with an array buffer', function (done) {
-			cw.ajax("test.json",function(a,cb){var b = new Uint32Array(a.split("").map(function(v){return v.charCodeAt()})).buffer; cb(b,[b])},true).then(function(a){ a.byteLength.should.deep.equal(52); }).then(done, done);
-		});
-	});
 	describe('Import Scripts', function () {
 		it("should be able to import scripts",function (done){
 			cw(function(a){importScripts('fakeLib.js');return a;}, 9).then(function (a) { a.should.equal(9); }).then(done, done);


### PR DESCRIPTION
the AJAX method was always more of a demo of what could be done, and frankly is the wrong way to use workers.  And as i said in #70 I'm going to depreciate it, aka I'm removing the references to it and then when I get around to doing a major version bump I'll remove it completely. 
