### PR TITLE
typeof module not enough

### DIFF
--- a/src/wrapup.js
+++ b/src/wrapup.js
@@ -50,7 +50,7 @@ function initBrowser(c){
 	global.cw = c;
 	
 }
-if(typeof module === "undefined" || typeof module.exports === "undefined" ){
+if(!('exports' in module)){
 	initBrowser(c);
 } else {
 	module.exports=c;

--- a/src/wrapup.js
+++ b/src/wrapup.js
@@ -50,7 +50,7 @@ function initBrowser(c){
 	global.cw = c;
 	
 }
-if(typeof module === "undefined" ){
+if(typeof module === "undefined" || typeof module.exports === "undefined" ){
 	initBrowser(c);
 } else {
 	module.exports=c;

--- a/src/wrapup.js
+++ b/src/wrapup.js
@@ -50,7 +50,7 @@ function initBrowser(c){
 	global.cw = c;
 	
 }
-if(!('exports' in module)){
+if(typeof module === "undefined" || !('exports' in module)){
 	initBrowser(c);
 } else {
 	module.exports=c;


### PR DESCRIPTION
In some testing environments `module` may in-fact be defined in a browser context. I am using karma and mocha, which is currently un-unit-testable because of this overuse of the term `module`. Just adding the extra catch for `module.exports` seems to solve the problem.
