### PR TITLE
made importScripts less coding convention dependent

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,15 +8,15 @@ function regexImports(string){
 	loopFunc = function(a,b){
 		if(b){
 			"importScripts("+b.split(",").forEach(function(cc){
-				matches[c.makeUrl(cc.slice(1,-1))]=true;
+				matches[c.makeUrl(cc.match(/\s*(\S*)\s*/)[1])]=true; // trim whitespace, add to matches
 			})+");\n";
 		}
 	};
 	while(match){
-		match = rest.match(/(importScripts\(.*?\);)/);
-		rest = rest.replace(/(importScripts\((?:.*?\.js[\'\"])?\);?)/,"\n");
+		match = rest.match(/(importScripts\(.*?\);?)/);
+		rest = rest.replace(/(importScripts\(\s*(?:[\'\"].*[\'\"])?\s*\);?)/,"\n");
 		if(match){
-			match[0].replace(/importScripts\((.*?\.js[\'\"])\);?/g,loopFunc);
+			match[0].replace(/importScripts\(\s*(?:[\'\"](.*)[\'\"])?\s*\);?/g,loopFunc);
 		}
 	}
 	matches = Object.keys(matches);


### PR DESCRIPTION
importScripts regex would end up in an infinite loop if it had a space in it.
I made the regex more tolerant of style and filename and made the script-string trimming slightly cleaner.
I haven't tested it to be completely foolproof but it should work with most conventions.
